### PR TITLE
Remove object literal value shorthand

### DIFF
--- a/lib/pusher-redux.js
+++ b/lib/pusher-redux.js
@@ -48,7 +48,7 @@ var addToQueue = function (func) {
 
 var successfullyConnected = function (data) {
   isConnected = true;
-  config.store.dispatch(pusherAction({ actionType: CONNECTED, data }));
+  config.store.dispatch(pusherAction({ actionType: CONNECTED, data: data }));
   runPending();
 };
 


### PR DESCRIPTION
By force of habit I used an ES6 feature and it broke the lib when build for production with `create-react-app`.
