### PR TITLE
Export getChannel function from module

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ Pusher-redux dispatches actions of the following format:
     };
 ```
 
+#### Get subscribed channels
+```javascript
+import { getChannel } from 'pusher-redux';
+...
+function emitClientEvent(eventName, eventData) {
+  // gets the channel from the client
+  var myChannel = getChannel('some-channel-name');
+
+  // triggers a client event
+  myChannel.trigger(eventName, eventData);
+}
+```
+
 ## Delayed Configuration
 Sometimes you want to authenticate user for receiving pusher information, but you don't have user credentials yet.
 In this case you can do the following:

--- a/lib/pusher-redux.js
+++ b/lib/pusher-redux.js
@@ -135,5 +135,14 @@ module.exports.unsubscribe = function (channelName, eventName, actionType) {
   });
 };
 
+module.exports.getChannel = function(channelName) {
+  var channel = config.socket.channel(channelName);
+  if (!channel) {
+    console.log('Not subscribed to \'' + channelName + '\'');
+    return;
+  }
+  return channel
+};
+
 module.exports.CONNECTED = CONNECTED;
 module.exports.DISCONNECTED = DISCONNECTED;


### PR DESCRIPTION
Previously, there was no way to access a channel object from outside the library

However, there are cases when this is necessary
 - for example, to trigger a client event somewhere in your code

So let's create and export a getChannel function that fetches an already-subscribed channel from the module